### PR TITLE
Fixed webpack-dev-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "test": "echo \"Error: no test specified\" && exit 1",
         "build-dev": "webpack --mode development",
         "build-prod": "webpack --mode production",
-        "start": "webpack-dev-server"
+        "start": "webpack-dev-server --mode development --open --hot"
     },
     "keywords": [],
     "author": "",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,28 +1,31 @@
 const path = require('path');
 
+// Plugins
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
 module.exports = {
     entry: {
-        dev: "./src/index.tsx",
+        dev: './src/index.tsx',
     },
     output: {
         path: path.resolve(__dirname, 'dist'),
-        filename: 'js/[name].bundle.js'
+        filename: 'js/[name].bundle.js',
     },
     devServer: {
         compress: true,
         port: 3000,
         hot: true,
     },
-    devtool: "source-map",
+    devtool: 'source-map',
     resolve: {
-        extensions: [".ts", ".tsx", ".js", ".jsx"],
+        extensions: ['.ts', '.tsx', '.js', '.jsx'],
     },
     module: {
         rules: [
             // Typescript
             {
                 test: /\.(ts|tsx)$/,
-                loader: "awesome-typescript-loader"
+                loader: 'awesome-typescript-loader',
             },
             {
                 test: /\.tsx?$/,
@@ -30,4 +33,9 @@ module.exports = {
             },
         ],
     },
+    plugins: [
+        new HtmlWebpackPlugin({
+            template: './src/index.html',
+        }),
+    ],
 };


### PR DESCRIPTION
### Issue
Looks like webpack was not aware of an `index.html` it could use as a template for serving your bundled code. 

### This solution
I simply added [html-webpack-plugin](https://github.com/jantimon/html-webpack-plugin) so that it could use it as a template. 

Also added a few flags (--mode, --open, and --hot) to make the experience a bit better. Definitions here: [webpack options](https://webpack.js.org/configuration/#options)